### PR TITLE
Add fs import

### DIFF
--- a/build/compile.js
+++ b/build/compile.js
@@ -3,6 +3,7 @@ var less = require('less'),
     utils = require('kanso-utils/utils'),
     spawn = require('child_process').spawn,
     attachments = require('kanso-utils/attachments'),
+    fs = require('fs'),
     path = require('path');
 
 


### PR DESCRIPTION
With a very bare bones kanso app, just this module and attachments, the fs module is not found. Adding the require fixes it right up.
